### PR TITLE
Support dbtest on CI environment

### DIFF
--- a/modules/iceaxe-dbtest/build.gradle
+++ b/modules/iceaxe-dbtest/build.gradle
@@ -7,3 +7,17 @@ dependencies {
     implementation "ch.qos.logback:logback-classic:1.2.3"
     implementation 'org.slf4j:slf4j-simple:1.7.32'
 }
+
+tasks.named('test') {
+    systemProperty 'tsurugi.dbtest.endpoint', findProperty('dbtest.endpoint') ?: 'tcp://localhost:12345'
+}
+
+if (hasProperty("dbtest.ci")) {
+    test {
+        filter {
+            excludeTestsMatching "com.tsurugidb.iceaxe.test.timeout.*"
+            excludeTestsMatching "com.tsurugidb.iceaxe.test.connector.DbErrorConnectTest"
+        }
+    }
+}
+

--- a/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/util/DbTestConnector.java
+++ b/modules/iceaxe-dbtest/src/test/java/com/tsurugidb/iceaxe/test/util/DbTestConnector.java
@@ -16,8 +16,13 @@ public class DbTestConnector {
     private static final String DB_HOST = "localhost";
     private static final int DB_PORT = 12345;
 
+    private static final String SYSPROP_DBTEST_ENDPOINT = "tsurugi.dbtest.endpoint";
+
     public static TsurugiConnector createConnector() {
-        var endpoint = URI.create("tcp://" + DB_HOST + ":" + DB_PORT);
+        String endpointString = System.getProperty(
+            SYSPROP_DBTEST_ENDPOINT, "tcp://" + DB_HOST + ":" + DB_PORT
+        );
+        var endpoint = URI.create(endpointString);
         return TsurugiConnector.createConnector(endpoint);
     }
 


### PR DESCRIPTION
- Enable to specify `dbtest.endpoint` for changing endpoint
- Enable to specify `dbtest.ci` for filtering tests on CI