### PR TITLE
Add Workflow: Iceaxe-CI-Javadoc

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,8 +5,6 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   Build:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     timeout-minutes: 30
     defaults:
       run:
@@ -45,3 +43,11 @@ jobs:
     if: github.repository_owner == 'project-tsurugi' && (contains(github.ref, '/tags/') || contains(github.ref, '/heads/master'))
     needs: Build
     secrets: inherit
+
+  GHPages:
+    uses: ./.github/workflows/ci-javadoc.yml
+    if: github.repository_owner == 'project-tsurugi' && (contains(github.ref, '/tags/'))
+    needs: Build
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.github/workflows/ci-javadoc.yml
+++ b/.github/workflows/ci-javadoc.yml
@@ -1,0 +1,36 @@
+name: Iceaxe-CI-Javadoc
+
+on: [workflow_dispatch, workflow_call]
+concurrency: ${{ github.workflow }}
+
+jobs:
+  GHPages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    env:
+      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
+
+    steps:
+      - name: Setup_Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build_Javadoc
+        run: |
+         ./gradlew -i clean iceaxe-core:javadoc
+
+      - name: Publish_Javadoc
+        uses: peaceiris/actions-gh-pages@v3.9.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: modules/iceaxe-core/build/docs/javadoc

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 Iceaxe is a Java library that executes SQL on Tsurugi database.
 
-[![javadoc](https://javadoc.io/badge2/com.tsurugidb.iceaxe/iceaxe-core/javadoc.svg)](https://javadoc.io/doc/com.tsurugidb.iceaxe/iceaxe-core)
-
 ## Requirements
 
 * Java `>= 11`
 
 * access to installed dependent modules:
   * Tsubakuro
+
+## Javadoc
+
+* https://project-tsurugi.github.io/iceaxe/
 
 ## How to build
 


### PR DESCRIPTION
This PR add CI workflow Iceaxe-CI-Javadoc for generate and publish javadoc to GitHub Pages
- https://project-tsurugi.github.io/iceaxe/