### PR TITLE
Add stub of javadoc overview.

### DIFF
--- a/modules/iceaxe-core/build.gradle
+++ b/modules/iceaxe-core/build.gradle
@@ -15,3 +15,8 @@ dependencies {
 spotbugs {
     excludeFilter = file("$projectDir/config/spotbugs/spotbugsExclude.xml")
 }
+
+javadoc {
+    title "Tsurugi Iceaxe ${project.version} API"
+    options.overview = 'src/main/javadoc/overview.html'
+}

--- a/modules/iceaxe-core/src/main/javadoc/overview.html
+++ b/modules/iceaxe-core/src/main/javadoc/overview.html
@@ -1,0 +1,5 @@
+<body>
+
+This document is API specification of Tsurugi Iceaxe.
+
+</body>


### PR DESCRIPTION
This introduces an example of overview statement of the Iceaxe API reference.

![image](https://github.com/project-tsurugi/iceaxe/assets/177860/0a9a7b49-5ae9-4b41-99bb-6d4c709ee9e7)
