### PR TITLE
ci: fix CI workflow permission

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,6 +5,8 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Regression in the following commit:
https://github.com/project-tsurugi/iceaxe/commit/b6a2c487e35e832712a3693dabdbf52d4e312462