### PR TITLE
build: bump back spotbugs-gradle-plugin to 5.2.5

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.5'
 }


### PR DESCRIPTION
Because spotbugs does not work correctly with the following error
```
java.io.IOException: No files to analyze could be opened
	at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:30
	at edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:395)
	at edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1231)
```