### PR TITLE
ci: bump actions/deploy-pages to v4

### DIFF
--- a/.github/workflows/ci-javadoc.yml
+++ b/.github/workflows/ci-javadoc.yml
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
 To fix compatibility with `actions/upload-pages-artifact@v3` .