### PR TITLE
build: introduce license-gradle-plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,4 +8,5 @@ repositories {
 
 dependencies {
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.5'
+    implementation 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
 }

--- a/buildSrc/src/main/groovy/iceaxe.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/iceaxe.java-conventions.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'checkstyle'
 
     id 'com.github.spotbugs'
+    id 'com.github.hierynomus.license'
 }
 
 group = 'com.tsurugidb.iceaxe'
@@ -115,4 +116,12 @@ task showTsubakuroManifest {
         def version = resources.text.fromArchiveEntry(tsubakuroJar, "META-INF/MANIFEST.MF")
         print(version.asString())
     }
+}
+
+license {
+    def confDir = 'buildSrc/src/main/resources'
+    header rootProject.file("$confDir/source-header.txt")
+    mapping('java', 'SLASHSTAR_STYLE')
+    include('**/*.java')
+    ignoreFailures true
 }

--- a/buildSrc/src/main/resources/source-header.txt
+++ b/buildSrc/src/main/resources/source-header.txt
@@ -1,0 +1,13 @@
+Copyright 2023-2024 Project Tsurugi.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This Pull Request introduce [License Gradle Plugin](https://github.com/hierynomus/license-gradle-plugin) for maintaining source header.