### PR TITLE
ci: modify runs-on for preventing ubuntu-latest

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
     timeout-minutes: 30

--- a/.github/workflows/ci-javadoc.yml
+++ b/.github/workflows/ci-javadoc.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, workflow_call]
 
 jobs:
   Prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     defaults:
       run:
@@ -33,7 +33,7 @@ jobs:
 
   Deplpy:
     needs: Prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, workflow_call]
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
As ubuntu 24.04 is currently still experimental support

See: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes