### PR TITLE
Fix to fail Gradle `PublishToMavenLocal` task with Release Version

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Publish
         run: |
-          ./gradlew -i iceaxe-core:showTsubakuroManifest clean publish --warning-mode all
+          ./gradlew -i iceaxe-core:showTsubakuroManifest clean publish --warning-mode all -PenableSign
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USER }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.5'
     implementation 'gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:0.16.1'
-    implementation 'com.vanniktech:gradle-maven-publish-plugin:0.32.0'
+    implementation 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
 }

--- a/buildSrc/src/main/groovy/iceaxe.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/iceaxe.java-conventions.gradle
@@ -12,6 +12,7 @@ version = '1.11.0-SNAPSHOT'
 ext {
     tsubakuroVersion = '1.11.0-SNAPSHOT'
     isReleaseVersion = !version.endsWith("SNAPSHOT")
+    isSignEnabled = project.hasProperty('enableSign')
 }
 
 if (hasProperty('mavenLocal')) {

--- a/buildSrc/src/main/groovy/iceaxe.libs-conventions.gradle
+++ b/buildSrc/src/main/groovy/iceaxe.libs-conventions.gradle
@@ -5,13 +5,12 @@ plugins {
     id 'iceaxe.java-conventions'
 }
 
-import com.vanniktech.maven.publish.SonatypeHost
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
 mavenPublishing {
     configure(new JavaLibrary(new JavadocJar.None(), true))
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     if (isReleaseVersion) {
         signAllPublications()

--- a/buildSrc/src/main/groovy/iceaxe.libs-conventions.gradle
+++ b/buildSrc/src/main/groovy/iceaxe.libs-conventions.gradle
@@ -12,7 +12,7 @@ mavenPublishing {
     configure(new JavaLibrary(new JavadocJar.None(), true))
     publishToMavenCentral()
 
-    if (isReleaseVersion) {
+    if (isReleaseVersion && isSignEnabled) {
         signAllPublications()
     }
 


### PR DESCRIPTION
This Pull Request fixes a bug where Gradle's `PublishToMavenLocal` task fails when executed for release versions.

This also bumps `vanniktech:gradle-maven-publish-plugin` to 0.34.0.
