### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Assemble
         run: |
@@ -33,7 +33,7 @@ jobs:
           ./gradlew -i check --continue --warning-mode all
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
         with:
           junit_input: '**/build/test-results/**/TEST-*.xml'

--- a/.github/workflows/ci-javadoc.yml
+++ b/.github/workflows/ci-javadoc.yml
@@ -14,20 +14,20 @@ jobs:
 
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build_Javadoc
         run: |
          ./gradlew -i clean iceaxe-core:javadoc --warning-mode all
 
       - name: Publish_Javadoc
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: modules/iceaxe-core/build/docs/javadoc
 
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Setup_Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Publish
         run: |


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/